### PR TITLE
Docs quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,15 +68,33 @@ git clone git@github.com:REASON-6G/mATRIC-master.git
 cd mATRIC-master
 ```
 
-Then, edit SECRET_KEY, FIRST_SUPERUSER, FIRST_SUPERUSER_PASSWORD in .env
-
 ```bash
 docker network create traefik-public
 docker compose up -d
 docker ps
 ```
 
-In a browser, navigate to localhost
+You then may need to restart the backend container, as it sometimes does not connect to the RabbitMQ container. If RabbitMQ is not ready before the backend launches then backend will simply crash and not restart by itself.
+
+```bash
+docker restart matric-master-backend-1
+```
+
+You then need to create the first superuser, you can do this with cURL, Postman, or your favourite HTTP client
+
+```bash
+curl --location 'http://localhost/api/v1/users/public' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+    "username": "test@example.com",
+    "password": "asdasd123",
+    "roles": ["admin"]
+}'
+```
+
+In a browser, navigate to localhost and log in using `test@example.com` / `asdasd123`
+
+You should now see the dashboard.
 
 ## How To Use It
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,23 @@ This repository host the mATRIC software implementation platform, an intelligent
 
 [![API docs](img/docs.png)](https://github.com/REASON-6G/mATRIC-master)
 
+## Quick start
+
+```bash
+git clone git@github.com:REASON-6G/mATRIC-master.git
+cd mATRIC-master
+```
+
+Then, edit SECRET_KEY, FIRST_SUPERUSER, FIRST_SUPERUSER_PASSWORD in .env
+
+```bash
+docker network create traefik-public
+docker compose up -d
+docker ps
+```
+
+In a browser, navigate to localhost
+
 ## How To Use It
 
 You can clone this repository as is.

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -108,4 +108,4 @@ services:
 
 networks:
   traefik-public:
-    external: false
+    external: true

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -4,11 +4,12 @@ services:
     ports:
       - 80:80
       - 443:443
+      - 8081:8080
     restart: always
     labels:
       - traefik.enable=true
       - traefik.constraint-label=traefik-public
-      - traefik.http.middlewares.https-redirect.contenttype.autodetect=false
+      - traefik.http.middlewares.https-redirect.contenttype
     command:
       - --providers.docker
       - --providers.docker.constraints=Label(`traefik.constraint-label`, `traefik-public`)
@@ -111,4 +112,4 @@ services:
 
 networks:
   traefik-public:
-    external: false
+    external: true

--- a/frontend/src/client/services.ts
+++ b/frontend/src/client/services.ts
@@ -48,6 +48,9 @@ export class LoginService {
       method: "POST",
       url: "/api/v1/token",
       formData: formData,
+      query: {
+        login_type: "user"
+      },
       mediaType: "application/x-www-form-urlencoded",
       errors: {
         422: `Validation Error`,


### PR DESCRIPTION
# Context

It was not possible to run the local development implementation by following the instructions. 

# Changes

* The frontend logs in to the url: http://localhost/api/v1/token, but the backend expects some additional params: http://localhost:api/v1/token?login_type=user. Without these params, the frontend returns 422 UNPROCESSABLE ENTITY, even if the credentials are correct. I made some modifications to the frontend code to always include the required params
* Quick-start documentation was added to instruct devs on getting the containers running
* The backend does not create a superuser on instantiation, and attempts to create a new user via the UI return with 405 errors. Documentation was added to instruct on use of the http://localhost/api/v1/users/public interface with cURL
* The docker network "traefik-public" was not deployed correctly across containers, it has been switched to an external network and the README has been updated to instruct on how to do this

# Other issues spotted

It is possible to create infinite admin users via the http://localhost/api/v1/users/public interface with this curl command

curl --location 'http://localhost/api/v1/users/public' \
--header 'Content-Type: application/json' \
--data-raw '{
    "username": "fff@example.com",
    "password": "asdasd123",
    "roles": ["admin"]
}'

This creates a critical security flaw and must be addressed

Before submitting your PR, please review the following checklist:

- [ ] **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] **DO** keep pull requests small so they can be easily reviewed.
- [ ] **DO** make sure unit tests pass.
- [ ] **DO** make sure any public APIs are documented.
- [ ] **DO** make sure not to introduce any compiler warnings.
- [ ] **AVOID** breaking the continuous integration build.
- [ ] **AVOID** making significant changes to the overall architecture.
